### PR TITLE
Increase timeout

### DIFF
--- a/input-pattern.html
+++ b/input-pattern.html
@@ -303,7 +303,7 @@
           const width = this.$.minsize.getBoundingClientRect().width;
           this._minSizeJob = null;
           if (width === 0) {
-            this._minSizeJob = setTimeout(minsizer.bind(this), 0);
+            this._minSizeJob = setTimeout(minsizer.bind(this), 100);
           } else {
             this.$.input.style.minWidth = `${width}px`;
             this._debouncedComputeWidth();


### PR DESCRIPTION
When the date-picker is not visible (e.g. because it's in a pop-up) the timeout-loop will take up all available processing time making CPU fans spin up for naught. Checking ten times per second instead of as fast as possible is sufficient - probably still too much but bearable, at least.